### PR TITLE
created a heroku config work around on configuration file

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,6 +8,11 @@ class Config(object):
     SECRET_KEY = os.environ.get('SECRET_KEY')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+    database_url = os.environ.get('DATABASE_URL')
+    if database_url.startswith('postgres://'):
+        database_url = database_url.replace('postgres://', 'postgresql://', 1)
+    SQLALCHEMY_DATABASE_URI = database_url
+
 
 class ProductionConfig(Config):
     DEBUG = True


### PR DESCRIPTION
### what does this PR do ?
It creates a work around on the configuration file to enable to bypass an 
error on Heroku that comes from deprecated sqlalchemy url strings for 
the database connection.